### PR TITLE
don't assume environment variables are set

### DIFF
--- a/src/raspberrycam/__main__.py
+++ b/src/raspberrycam/__main__.py
@@ -35,10 +35,11 @@ def main(debug: bool = False, interval: int = 10800) -> None:
     camera = PiCamera(1024, 768)
 
     # Option to set these in .env - they will load automatically
-    AWS_ROLE_ARN = os.environ["AWS_ROLE_ARN"]
-    AWS_BUCKET_NAME = os.environ["AWS_BUCKET_NAME"]
-    AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
-    AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
+    # These will fall back to empty strings if they're not set in environment
+    AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
+    AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME", "")
+    AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
+    AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 
     s3_manager = S3Manager(
         role_arn=AWS_ROLE_ARN, access_key_id=AWS_ACCESS_KEY_ID, secret_access_key=AWS_SECRET_ACCESS_KEY

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -10,12 +10,10 @@ from raspberrycam.image import ImageManager, S3ImageManager
 from raspberrycam.s3 import S3Manager
 
 load_dotenv()
-AWS_ROLE_ARN = os.environ["AWS_ROLE_ARN"]
-AWS_BUCKET_NAME = os.environ["AWS_BUCKET_NAME"]
-AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
-AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
-
-s3 = S3Manager(role_arn=AWS_ROLE_ARN, access_key_id=AWS_ACCESS_KEY_ID, secret_access_key=AWS_SECRET_ACCESS_KEY)
+AWS_ROLE_ARN = os.environ.get("AWS_ROLE_ARN", "")
+AWS_BUCKET_NAME = os.environ.get("AWS_BUCKET_NAME", "")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
 
 
 # There are two of these Image Managers, one local and one S3 based


### PR DESCRIPTION
Retrieving a dictionary key that isn't set throws a python `KeyError`

The first version of this project had a default `.env` file in its root, so the connection values stored in environment variables were always set (even if just to empty strings)

This change just catches the behaviour if we don't have a `.env` file in our project (use "`.get` to check whether the key exists and return a default value if it doesn't, rather than assume it exists)